### PR TITLE
Make Subscription Source Configurable

### DIFF
--- a/commons/src/main/scala/com/flipkart/connekt/commons/entities/Subscription.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/entities/Subscription.scala
@@ -26,6 +26,9 @@ class Subscription {
   @Column(name = "name")
   var name: String = _
 
+  @Column(name = "source")
+  var source : String  = _
+
   @Column(name = "sink")
   var sink : EventSink  = _
 
@@ -47,17 +50,17 @@ class Subscription {
   @Column(name = "active")
   var active : Boolean = false
 
-  def this(sId: String, sName: String, endpoint: EventSink, createdBy: String,
+  def this(sId: String, sName: String, source:String, endpoint: EventSink, createdBy: String,
            stencilId:String, shutdownThreshold: Int) = {
     this
     this.id = sId
     this.name = sName
+    this.source = source
     this.sink = endpoint
     this.createdBy = createdBy
     this.stencilId = stencilId
     this.shutdownThreshold = shutdownThreshold
   }
 
-  override def toString =
-    s"Subscription($id, $name, ${sink.getJson}, $createdBy, ${createdTS.toString}, ${lastUpdatedTS.toString}, $stencilId, $shutdownThreshold)"
+  override def toString = s"Subscription(id=$id, name=$name, source=$source, sink=${sink.getJson}, createdBy=$createdBy, createdTS=$createdTS, lastUpdatedTS=$lastUpdatedTS, stencilId=$stencilId, shutdownThreshold=$shutdownThreshold, active=$active)"
 }

--- a/firefly/src/main/scala/com/flipkart/connekt/firefly/ClientTopology.scala
+++ b/firefly/src/main/scala/com/flipkart/connekt/firefly/ClientTopology.scala
@@ -32,15 +32,15 @@ import scala.concurrent.Promise
 
 class ClientTopology(topic: String, retryLimit: Int, kafkaConsumerConnConf: Config, subscription: Subscription)(implicit am: ActorMaterializer, sys: ActorSystem) {
 
-  implicit val ec = am.executionContext
+  private implicit val ec = am.executionContext
 
-  val stencilService = ServiceFactory.getStencilService
+  private val stencilService = ServiceFactory.getStencilService
 
-  lazy val stencil = Option(subscription.stencilId).map(stencilService.get(_)).getOrElse(List.empty)
+  private lazy val stencil = Option(subscription.stencilId).map(stencilService.get(_)).getOrElse(List.empty)
 
-  lazy val eventFilterStencil = stencil.find(_.component == "eventFilter")
-  lazy val eventHeaderTransformer = stencil.find(_.component == "header")
-  lazy val eventPayloadTransformer = stencil.find(_.component == "payload")
+  private lazy val eventFilterStencil = stencil.find(_.component == "eventFilter")
+  private lazy val eventHeaderTransformer = stencil.find(_.component == "header")
+  private lazy val eventPayloadTransformer = stencil.find(_.component == "payload")
 
   def start(): Promise[String] = {
 
@@ -49,9 +49,9 @@ class ClientTopology(topic: String, retryLimit: Int, kafkaConsumerConnConf: Conf
     val source = Source.fromGraph(kafkaCallbackSource).filter(evaluator).map(transform).filter(null != _.payload)
 
     subscription.sink match {
-      case http: HTTPEventSink => source.runWith(new HttpSink(subscription, retryLimit, topologyShutdownTrigger).getHttpSink)
+      case _: HTTPEventSink => source.runWith(new HttpSink(subscription, retryLimit, topologyShutdownTrigger).getHttpSink)
       case kafka: KafkaEventSink => source.runWith(new KafkaSink(kafka.topic, kafka.broker).getKafkaSink)
-      case specter: SpecterEventSink =>
+      case _: SpecterEventSink =>
         source.runWith(new SpecterSink().sink)
     }
 
@@ -63,7 +63,7 @@ class ClientTopology(topic: String, retryLimit: Int, kafkaConsumerConnConf: Conf
 
     eventFilterStencil match {
       case None => true
-      case Some(stencil) => stencilService.materialize(stencil, data.getJson.getObj[ObjectNode]).asInstanceOf[Boolean]
+      case Some(filterStencil) => stencilService.materialize(filterStencil, data.getJsonNode).asInstanceOf[Boolean]
     }
   }
 
@@ -71,10 +71,10 @@ class ClientTopology(topic: String, retryLimit: Int, kafkaConsumerConnConf: Conf
 
     SubscriptionEvent(header = eventHeaderTransformer match {
       case None => null
-      case Some(stencil) => stencilService.materialize(stencil, event.getJson.getObj[ObjectNode]).asInstanceOf[java.util.HashMap[String, String]].asScala.toMap
+      case Some(headerStencil) => stencilService.materialize(headerStencil, event.getJsonNode).asInstanceOf[java.util.HashMap[String, String]].asScala.toMap
     }, payload = eventPayloadTransformer match {
       case None => event.getJson
-      case Some(stencil) => stencilService.materialize(stencil, event.getJson.getObj[ObjectNode])
+      case Some(payloadStencil) => stencilService.materialize(payloadStencil, event.getJsonNode)
     })
   }
 }

--- a/firefly/src/main/scala/com/flipkart/connekt/firefly/FireflyBoot.scala
+++ b/firefly/src/main/scala/com/flipkart/connekt/firefly/FireflyBoot.scala
@@ -65,7 +65,7 @@ object FireflyBoot extends BaseApp {
 
       HttpDispatcher.apply(ConnektConfig.getConfig("react").get)
 
-      ClientTopologyManager(kafkaConnConf, ConnektConfig.getString("firefly.kafka.topic").get, ConnektConfig.getInt("firefly.retry.limit").get)
+      ClientTopologyManager(kafkaConnConf, ConnektConfig.getInt("firefly.retry.limit").get)
 
       ConnektLogger(LogFile.SERVICE).info("Started `Firefly` app")
     }


### PR DESCRIPTION
Why? 

Today we use a single topic for firefly, and all are mandatorily callback events. Inbound events like sms/inbound-email are not callback events and would have a different structure. Hence making source topic as part of subscription definition, to allow re-use of firefly for relaying other event types. 

Other Changes: Fix scala warnings.