### PR TITLE
Scalable Pull Notifications 

### DIFF
--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/BusyBeesBoot.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/BusyBeesBoot.scala
@@ -88,6 +88,8 @@ object BusyBeesBoot extends BaseApp {
       val kafkaProducerPoolConf = ConnektConfig.getConfig("connections.kafka.producerPool").getOrElse(ConfigFactory.empty())
       val kafkaProducerHelper = KafkaProducerHelper.init(kafkaProducerConnConf, kafkaProducerPoolConf)
 
+      ServiceFactory.initMessageQueueService(DaoFactory.getMessageQueueDao)
+
       val eventsDao = EventsDaoContainer(pnEventsDao = DaoFactory.getPNCallbackDao, emailEventsDao = DaoFactory.getEmailCallbackDao, smsEventsDao = DaoFactory.getSmsCallbackDao)
       val requestDao = RequestDaoContainer(smsRequestDao = DaoFactory.getSmsRequestDao, pnRequestDao = DaoFactory.getPNRequestDao, emailRequestDao = DaoFactory.getEmailRequestDao)
       ServiceFactory.initCallbackService(eventsDao, requestDao, kafkaProducerHelper)

--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/BusyBeesBoot.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/BusyBeesBoot.scala
@@ -73,6 +73,9 @@ object BusyBeesBoot extends BaseApp {
       val couchbaseCf = ConnektConfig.getConfig("connections.couchbase").getOrElse(ConfigFactory.empty())
       DaoFactory.initCouchbaseCluster(couchbaseCf)
 
+      val aeroSpikeCf = ConnektConfig.getConfig("connections.aerospike").getOrElse(ConfigFactory.empty())
+      DaoFactory.initAeroSpike(aeroSpikeCf)
+
       DaoFactory.initReportingDao(DaoFactory.getCouchbaseBucket("StatsReporting"))
 
       ServiceFactory.initStorageService(DaoFactory.getKeyChainDao)

--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/eventcreators/NotificationQueueRecorder.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/eventcreators/NotificationQueueRecorder.scala
@@ -18,13 +18,15 @@ import com.flipkart.connekt.commons.factories.{ConnektLogger, LogFile, ServiceFa
 import com.flipkart.connekt.commons.helpers.ConnektRequestHelper._
 import com.flipkart.connekt.commons.iomodels.MessageStatus.InternalStatus
 import com.flipkart.connekt.commons.iomodels.{ConnektRequest, PNRequestInfo}
+import com.flipkart.connekt.commons.metrics.Instrumented
 import com.flipkart.connekt.commons.utils.StringUtils._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-class NotificationQueueRecorder(parallelism: Int)(implicit ec: ExecutionContext) extends MapAsyncFlowStage[ConnektRequest, ConnektRequest](parallelism) {
+class NotificationQueueRecorder(parallelism: Int)(implicit ec: ExecutionContext) extends MapAsyncFlowStage[ConnektRequest, ConnektRequest](parallelism) with Instrumented {
   override val map: (ConnektRequest) => Future[List[ConnektRequest]] = message => {
+    val profiler = timer("map").time()
     try {
       ConnektLogger(LogFile.PROCESSORS).info(s"NotificationQueueRecorder received message: ${message.id}")
 
@@ -35,15 +37,15 @@ class NotificationQueueRecorder(parallelism: Int)(implicit ec: ExecutionContext)
         promise.success(List(message))
       else {
         val enqueueFutures = pnInfo.deviceIds.map(ServiceFactory.getMessageQueueService.enqueueMessage(message.appName, _, message.id))
-
         Future.sequence(enqueueFutures).andThen {
-          case Success(_) => promise.success(List(message))
+          case Success(_) =>
+            promise.success(List(message))
           case Failure(ex) =>
             ConnektLogger(LogFile.PROCESSORS).error(s"NotificationQueueRecorder MessageQueueService.enqueueMessage failed for ${message.id}", ex)
             promise.success(List(message))
         }
       }
-
+      promise.future.onComplete(_ => profiler.stop())
       promise.future
     } catch {
       case e: Exception =>

--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/eventcreators/NotificationQueueRecorder.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/eventcreators/NotificationQueueRecorder.scala
@@ -1,0 +1,41 @@
+package com.flipkart.connekt.busybees.streams.flows.eventcreators
+
+import com.flipkart.connekt.busybees.streams.errors.ConnektPNStageException
+import com.flipkart.connekt.busybees.streams.flows.MapAsyncFlowStage
+import com.flipkart.connekt.commons.factories.{ConnektLogger, LogFile}
+import com.flipkart.connekt.commons.helpers.ConnektRequestHelper._
+import com.flipkart.connekt.commons.iomodels.MessageStatus.InternalStatus
+import com.flipkart.connekt.commons.iomodels.{ConnektRequest, PNRequestInfo}
+import com.flipkart.connekt.commons.services.MessageQueueService
+import com.flipkart.connekt.commons.utils.StringUtils._
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
+
+class NotificationQueueRecorder(parallelism: Int)(ec: ExecutionContext) extends MapAsyncFlowStage[ConnektRequest, ConnektRequest](parallelism) {
+  override val map: (ConnektRequest) => Future[List[ConnektRequest]] = message => {
+    try {
+      ConnektLogger(LogFile.PROCESSORS).info(s"NotificationQueueRecorder received message: ${message.id}")
+      ConnektLogger(LogFile.PROCESSORS).trace(s"NotificationQueueRecorder received message: {}", supplier(message))
+
+      val pnInfo = message.channelInfo.asInstanceOf[PNRequestInfo]
+      val enqueueFutures = pnInfo.deviceIds.map(MessageQueueService.enqueueMessage(message.appName, _, message.id))
+
+      val promise = Promise[List[ConnektRequest]]()
+
+      Future.sequence(enqueueFutures).andThen {
+        case Success(_) => promise.success(List(message))
+        case Failure(ex) =>
+          ConnektLogger(LogFile.PROCESSORS).error(s"NotificationQueueRecorder MessageQueueService.enqueueMessage failed for ${message.id}", ex)
+          promise.success(List(message))
+      }
+
+      promise.future
+    } catch {
+      case e: Exception =>
+        ConnektLogger(LogFile.PROCESSORS).error(s"NotificationQueueRecorder error for ${message.id}", e)
+        throw ConnektPNStageException(message.id, message.clientId, message.destinations, InternalStatus.StageError, message.appName, message.platform, message.contextId.orEmpty, message.meta, "NotificationQueueRecorder::".concat(e.getMessage), e)
+    }
+
+  }
+}

--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/eventcreators/NotificationQueueRecorder.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/eventcreators/NotificationQueueRecorder.scala
@@ -1,33 +1,47 @@
+/*
+ *         -╥⌐⌐⌐⌐            -⌐⌐⌐⌐-
+ *      ≡╢░░░░⌐\░░░φ     ╓╝░░░░⌐░░░░╪╕
+ *     ╣╬░░`    `░░░╢┘ φ▒╣╬╝╜     ░░╢╣Q
+ *    ║╣╬░⌐        ` ╤▒▒▒Å`        ║╢╬╣
+ *    ╚╣╬░⌐        ╔▒▒▒▒`«╕        ╢╢╣▒
+ *     ╫╬░░╖    .░ ╙╨╨  ╣╣╬░φ    ╓φ░╢╢Å
+ *      ╙╢░░░░⌐"░░░╜     ╙Å░░░░⌐░░░░╝`
+ *        ``˚¬ ⌐              ˚˚⌐´
+ *
+ *      Copyright © 2016 Flipkart.com
+ */
 package com.flipkart.connekt.busybees.streams.flows.eventcreators
 
 import com.flipkart.connekt.busybees.streams.errors.ConnektPNStageException
 import com.flipkart.connekt.busybees.streams.flows.MapAsyncFlowStage
-import com.flipkart.connekt.commons.factories.{ConnektLogger, LogFile}
+import com.flipkart.connekt.commons.factories.{ConnektLogger, LogFile, ServiceFactory}
 import com.flipkart.connekt.commons.helpers.ConnektRequestHelper._
 import com.flipkart.connekt.commons.iomodels.MessageStatus.InternalStatus
 import com.flipkart.connekt.commons.iomodels.{ConnektRequest, PNRequestInfo}
-import com.flipkart.connekt.commons.services.MessageQueueService
 import com.flipkart.connekt.commons.utils.StringUtils._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-class NotificationQueueRecorder(parallelism: Int)(ec: ExecutionContext) extends MapAsyncFlowStage[ConnektRequest, ConnektRequest](parallelism) {
+class NotificationQueueRecorder(parallelism: Int)(implicit ec: ExecutionContext) extends MapAsyncFlowStage[ConnektRequest, ConnektRequest](parallelism) {
   override val map: (ConnektRequest) => Future[List[ConnektRequest]] = message => {
     try {
       ConnektLogger(LogFile.PROCESSORS).info(s"NotificationQueueRecorder received message: ${message.id}")
-      ConnektLogger(LogFile.PROCESSORS).trace(s"NotificationQueueRecorder received message: {}", supplier(message))
 
       val pnInfo = message.channelInfo.asInstanceOf[PNRequestInfo]
-      val enqueueFutures = pnInfo.deviceIds.map(MessageQueueService.enqueueMessage(message.appName, _, message.id))
-
       val promise = Promise[List[ConnektRequest]]()
 
-      Future.sequence(enqueueFutures).andThen {
-        case Success(_) => promise.success(List(message))
-        case Failure(ex) =>
-          ConnektLogger(LogFile.PROCESSORS).error(s"NotificationQueueRecorder MessageQueueService.enqueueMessage failed for ${message.id}", ex)
-          promise.success(List(message))
+      if(message.isTestRequest)
+        promise.success(List(message))
+      else {
+        val enqueueFutures = pnInfo.deviceIds.map(ServiceFactory.getMessageQueueService.enqueueMessage(message.appName, _, message.id))
+
+        Future.sequence(enqueueFutures).andThen {
+          case Success(_) => promise.success(List(message))
+          case Failure(ex) =>
+            ConnektLogger(LogFile.PROCESSORS).error(s"NotificationQueueRecorder MessageQueueService.enqueueMessage failed for ${message.id}", ex)
+            promise.success(List(message))
+        }
       }
 
       promise.future

--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/formaters/EmailChannelFormatter.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/flows/formaters/EmailChannelFormatter.scala
@@ -83,7 +83,7 @@ class EmailChannelFormatter(parallelism: Int)(implicit ec: ExecutionContextExecu
     } catch {
       case e: Exception =>
         ConnektLogger(LogFile.PROCESSORS).error(s"EmailChannelFormatter error for ${message.id}", e)
-        throw new ConnektStageException(message.id, message.clientId, message.destinations, InternalStatus.StageError, message.appName, Channel.EMAIL, message.contextId.orEmpty, message.meta, "AndroidChannelFormatter::".concat(e.getMessage), e)
+        throw ConnektStageException(message.id, message.clientId, message.destinations, InternalStatus.StageError, message.appName, Channel.EMAIL, message.contextId.orEmpty, message.meta, "EmailChannelFormatter::".concat(e.getMessage), e)
     }
   }
 }

--- a/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/topologies/PushTopology.scala
+++ b/busybees/src/main/scala/com/flipkart/connekt/busybees/streams/topologies/PushTopology.scala
@@ -19,7 +19,7 @@ import akka.stream.scaladsl._
 import com.flipkart.connekt.busybees.models.WNSRequestTracker
 import com.flipkart.connekt.busybees.streams.ConnektTopology
 import com.flipkart.connekt.busybees.streams.flows.dispatchers._
-import com.flipkart.connekt.busybees.streams.flows.eventcreators.PNBigfootEventCreator
+import com.flipkart.connekt.busybees.streams.flows.eventcreators.{NotificationQueueRecorder, PNBigfootEventCreator}
 import com.flipkart.connekt.busybees.streams.flows.formaters._
 import com.flipkart.connekt.busybees.streams.flows.profilers.TimedFlowOps._
 import com.flipkart.connekt.busybees.streams.flows.reponsehandlers._
@@ -80,12 +80,14 @@ class PushTopology(kafkaConsumerConfig: Config) extends ConnektTopology[PNCallba
     val render = b.add(new RenderFlow().flow)
     val fmtAndroidParallelism = ConnektConfig.getInt("topology.push.androidFormatter.parallelism").get
     val androidFilter = b.add(Flow[ConnektRequest].filter(m => MobilePlatform.ANDROID.toString.equalsIgnoreCase(m.channelInfo.asInstanceOf[PNRequestInfo].platform.toLowerCase)))
+    val notificationQueueParallelism = ConnektConfig.getInt("topology.push.queue.parallelism").get
+    val notificationQueueRecorder = b.add(new NotificationQueueRecorder(notificationQueueParallelism)(ioDispatcher).flow)
     val fmtAndroid = b.add(new AndroidChannelFormatter(fmtAndroidParallelism)(ioDispatcher).flow)
     val gcmHttpPrepare = b.add(new GCMDispatcherPrepare().flow)
     val gcmPoolFlow = b.add(HttpDispatcher.gcmPoolClientFlow.timedAs("gcmRTT"))
     val gcmResponseHandle = b.add(new GCMResponseHandler()(ioMat, ioDispatcher).flow)
 
-    render.out ~> androidFilter ~> fmtAndroid ~> gcmHttpPrepare ~> gcmPoolFlow ~> gcmResponseHandle
+    render.out ~> androidFilter ~> notificationQueueRecorder ~> fmtAndroid ~> gcmHttpPrepare ~> gcmPoolFlow ~> gcmResponseHandle
 
     FlowShape(render.in, gcmResponseHandle.out)
   })
@@ -103,12 +105,14 @@ class PushTopology(kafkaConsumerConfig: Config) extends ConnektTopology[PNCallba
     val fmtIOSParallelism = ConnektConfig.getInt("topology.push.iosFormatter.parallelism").get
     val apnsDispatcherParallelism = ConnektConfig.getInt("topology.push.apnsDispatcher.parallelism").getOrElse(1024)
     val iosFilter = b.add(Flow[ConnektRequest].filter(m => MobilePlatform.IOS.toString.equalsIgnoreCase(m.channelInfo.asInstanceOf[PNRequestInfo].platform.toLowerCase)))
+    val notificationQueueParallelism = ConnektConfig.getInt("topology.push.queue.parallelism").get
+    val notificationQueueRecorder = b.add(new NotificationQueueRecorder(notificationQueueParallelism)(ioDispatcher).flow)
     val fmtIOS = b.add(new IOSChannelFormatter(fmtIOSParallelism)(ioDispatcher).flow)
     val apnsPrepare = b.add(new APNSDispatcherPrepare().flow)
     val apnsDispatcher = b.add(new APNSDispatcher(apnsDispatcherParallelism)(ioDispatcher).flow.timedAs("apnsRTT"))
     val apnsResponseHandle = b.add(new APNSResponseHandler().flow)
 
-    render.out ~> iosFilter ~> fmtIOS ~> apnsPrepare ~> apnsDispatcher ~> apnsResponseHandle
+    render.out ~> iosFilter ~> notificationQueueRecorder ~> fmtIOS ~> apnsPrepare ~> apnsDispatcher ~> apnsResponseHandle
 
     FlowShape(render.in, apnsResponseHandle.out)
   })
@@ -132,6 +136,9 @@ class PushTopology(kafkaConsumerConfig: Config) extends ConnektTopology[PNCallba
     val wnsPayloadMerge = b.add(MergePreferred[WNSPayloadEnvelope](1))
     val wnsRetryMapper = b.add(Flow[WNSRequestTracker].map(_.request) /*.buffer(10, OverflowStrategy.backpressure)*/)
 
+    val notificationQueueParallelism = ConnektConfig.getInt("topology.push.queue.parallelism").get
+    val notificationQueueRecorder = b.add(new NotificationQueueRecorder(notificationQueueParallelism)(ioDispatcher).flow)
+
     val fmtWindowsParallelism = ConnektConfig.getInt("topology.push.windowsFormatter.parallelism").get
     val fmtWindows = b.add(new WindowsChannelFormatter(fmtWindowsParallelism)(ioDispatcher).flow)
 
@@ -142,7 +149,7 @@ class PushTopology(kafkaConsumerConfig: Config) extends ConnektTopology[PNCallba
       case Left(_) => 1
     }))
 
-    render.out ~> windowsFilter ~>  fmtWindows ~>  wnsPayloadMerge
+    render.out ~> windowsFilter ~> notificationQueueRecorder ~>  fmtWindows ~>  wnsPayloadMerge
     wnsPayloadMerge.out ~> wnsHttpPrepare  ~> wnsPoolFlow ~> wnsRHandler ~> wnsRetryPartition.in
     wnsPayloadMerge.preferred <~ wnsRetryMapper <~ wnsRetryPartition.out(1).map(_.left.get).outlet
 
@@ -162,6 +169,8 @@ class PushTopology(kafkaConsumerConfig: Config) extends ConnektTopology[PNCallba
     val render = b.add(new RenderFlow().flow)
     val fmtOpenWebParallelism = ConnektConfig.getInt("topology.push.openwebFormatter.parallelism").get
     val openWebFilter = b.add(Flow[ConnektRequest].filter(m => MobilePlatform.OPENWEB.toString.equalsIgnoreCase(m.channelInfo.asInstanceOf[PNRequestInfo].platform.toLowerCase)))
+    val notificationQueueParallelism = ConnektConfig.getInt("topology.push.queue.parallelism").get
+    val notificationQueueRecorder = b.add(new NotificationQueueRecorder(notificationQueueParallelism)(ioDispatcher).flow)
     val fmtOpenWeb = b.add(new OpenWebChannelFormatter(fmtOpenWebParallelism)(ioDispatcher).flow)
 
     //providers [standard]
@@ -169,7 +178,7 @@ class PushTopology(kafkaConsumerConfig: Config) extends ConnektTopology[PNCallba
     val openWebPoolFlow = b.add(HttpDispatcher.openWebPoolClientFlow.timedAs("openWebRTT"))
     val openWebResponseHandle = b.add(new OpenWebResponseHandler()(ioMat, ioDispatcher).flow)
 
-    render.out ~> openWebFilter ~> fmtOpenWeb ~> openWebHttpPrepare ~> openWebPoolFlow ~> openWebResponseHandle
+    render.out ~> openWebFilter ~> notificationQueueRecorder ~> fmtOpenWeb ~> openWebHttpPrepare ~> openWebPoolFlow ~> openWebResponseHandle
 
     FlowShape(render.in, openWebResponseHandle.out)
   })

--- a/commons/build.sbt
+++ b/commons/build.sbt
@@ -113,7 +113,8 @@ libraryDependencies ++= Seq(
   "org.jsoup" % "jsoup" % "1.8.3",
   "com.googlecode.libphonenumber" % "libphonenumber" % "8.3.1",
   "com.rabbitmq" % "amqp-client" % "4.0.1",
-  "net.freeutils" % "jcharset" % "2.0"
+  "net.freeutils" % "jcharset" % "2.0",
+  "com.aerospike" % "aerospike-client" % "3.3.3"
 )
 
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/connections/ConnectionProvider.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/connections/ConnectionProvider.scala
@@ -32,5 +32,10 @@ class ConnectionProvider extends TConnectionProvider {
 
   override def createCouchBaseConnection(nodes: List[String]): Cluster = CouchbaseCluster.create(nodes.asJava)
 
-  override def createAeroSpikeConnection(nodes: List[String]): AsyncClient =  new AsyncClient(new AsyncClientPolicy(), nodes.map(new Host(_, 3000)): _ *)
+  override def createAeroSpikeConnection(nodes: List[String]): AsyncClient =  {
+    val asyncClientPolicy = new AsyncClientPolicy()
+    asyncClientPolicy.asyncMaxCommands = 500
+    asyncClientPolicy.asyncSelectorThreads = 4
+    new AsyncClient(asyncClientPolicy, nodes.map(new Host(_, 3000)): _ *)
+  }
 }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/connections/ConnectionProvider.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/connections/ConnectionProvider.scala
@@ -15,6 +15,8 @@ package com.flipkart.connekt.commons.connections
 import java.util.Properties
 import javax.sql.DataSource
 
+import com.aerospike.client.Host
+import com.aerospike.client.async.{AsyncClient, AsyncClientPolicy}
 import com.couchbase.client.java.{Cluster, CouchbaseCluster}
 import org.apache.commons.dbcp2.BasicDataSourceFactory
 import org.apache.hadoop.conf.Configuration
@@ -29,4 +31,6 @@ class ConnectionProvider extends TConnectionProvider {
   override def createDatasourceConnection(mySQLProperties: Properties): DataSource = BasicDataSourceFactory.createDataSource(mySQLProperties)
 
   override def createCouchBaseConnection(nodes: List[String]): Cluster = CouchbaseCluster.create(nodes.asJava)
+
+  override def createAeroSpikeConnection(nodes: List[String]): AsyncClient =  new AsyncClient(new AsyncClientPolicy(), nodes.map(new Host(_, 3000)): _ *)
 }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/connections/TConnectionProvider.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/connections/TConnectionProvider.scala
@@ -15,6 +15,7 @@ package com.flipkart.connekt.commons.connections
 import java.util.Properties
 import javax.sql.DataSource
 
+import com.aerospike.client.async.AsyncClient
 import com.couchbase.client.java.Cluster
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.client.Connection
@@ -22,6 +23,8 @@ import org.apache.hadoop.hbase.client.Connection
 abstract class TConnectionProvider {
 
   def createCouchBaseConnection(nodes: List[String]): Cluster
+
+  def createAeroSpikeConnection(nodes: List[String]): AsyncClient
 
   def createHbaseConnection(hConnConfig: Configuration) : Connection
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
@@ -24,7 +24,7 @@ import com.flipkart.connekt.commons.services.ConnektConfig
 import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
 
-trait AeroSpikeDao extends Instrumented {
+trait AeroSpikeDao  extends  Instrumented {
 
   lazy val timeout: Int = ConnektConfig.getInt("connections.aerospike.timeout").getOrElse(500)
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
@@ -1,0 +1,131 @@
+package com.flipkart.connekt.commons.dao
+
+import akka.http.scaladsl.util.FastFuture
+import com.aerospike.client.Value.StringValue
+import com.aerospike.client.async.AsyncClient
+import com.aerospike.client.listener.{DeleteListener, RecordListener, WriteListener}
+import com.aerospike.client.policy.WritePolicy
+import com.aerospike.client._
+import com.aerospike.client.cdt.{ListOperation, MapOperation, MapPolicy, MapReturnType}
+import com.flipkart.connekt.commons.connections.ConnectionProvider
+import com.flipkart.connekt.commons.metrics.Instrumented
+import com.flipkart.connekt.commons.services.ConnektConfig
+
+import collection.JavaConverters._
+import collection.JavaConverters._
+import scala.concurrent.{Await, Future, Promise}
+
+import scala.concurrent.duration._
+
+trait AeroSpikeDao extends Instrumented {
+
+  lazy val timeout: Int = 500 //ConnektConfig.getInt("connections.aerospike.timeout").getOrElse(500)
+
+  protected def addRow(key: Key, bin: Bin, ttl: Option[Long] = None)(implicit client: AsyncClient): Future[Boolean] = {
+    val policy = new WritePolicy()
+    policy.timeout = timeout
+    ttl.foreach(millis => policy.expiration = (millis / 1000).toInt)
+    val promise = Promise[Boolean]()
+    client.put(policy, new AeroSpikeWriteHandler(promise), key, bin)
+    promise.future
+  }
+
+  protected def addMapRow(key: Key, binName: String, values: Map[String, String], ttl: Option[Long] = None)(implicit client: AsyncClient): Future[Record] = {
+    val policy = new WritePolicy()
+    policy.timeout = timeout
+    ttl.foreach(millis => policy.expiration = (millis / 1000).toInt)
+
+    val data: Map[Value, Value] = values.map { case (k, v) => (new StringValue(k), new StringValue(v)) }
+    val promise = Promise[Record]()
+    val record = client.operate(policy, key, MapOperation.putItems(MapPolicy.Default, binName, data.asJava))
+
+    println(record)
+
+    promise.future
+
+    FastFuture.successful(new Record(Map.empty[String,AnyRef].asJava,0,0))
+  }
+
+  protected def deleteMapRowItems(key: Key, binName: String, keys: List[String])(implicit client: AsyncClient): Future[Record] = {
+    val policy = new WritePolicy()
+    policy.timeout = timeout
+
+    val _keys: List[Value] = keys.map(new StringValue(_))
+
+    val promise = Promise[Record]()
+    client.operate(policy, new AeroSpikeRecordHandler(promise), key, MapOperation.removeByKeyList(binName, _keys.asJava, MapReturnType.COUNT))
+    promise.future
+  }
+
+  protected def getRow(key: Key)(implicit client: AsyncClient): Future[Record] = {
+    val policy = new WritePolicy()
+    policy.timeout = timeout
+    val promise = Promise[Record]()
+    client.get(policy, new AeroSpikeRecordHandler(promise), key)
+    promise.future
+  }
+
+  protected def deleteRow(key: Key)(implicit client: AsyncClient): Future[Boolean] = {
+    val policy = new WritePolicy()
+    policy.timeout = timeout
+    val promise = Promise[Boolean]()
+    client.delete(policy, new AeroSpikeDeleteHandler(promise), key)
+    promise.future
+  }
+
+
+}
+
+
+private class AeroSpikeWriteHandler(promise: Promise[Boolean]) extends WriteListener {
+  override def onFailure(exception: AerospikeException): Unit = promise.failure(exception)
+
+  override def onSuccess(key: Key): Unit = promise.success(true)
+}
+
+private class AeroSpikeRecordHandler(promise: Promise[Record]) extends RecordListener {
+  override def onFailure(exception: AerospikeException): Unit = promise.failure(exception)
+
+  override def onSuccess(key: Key, record: Record): Unit = promise.success(record)
+}
+
+private class AeroSpikeDeleteHandler(promise: Promise[Boolean]) extends DeleteListener {
+  override def onFailure(exception: AerospikeException): Unit = promise.failure(exception)
+
+  override def onSuccess(key: Key, existed: Boolean): Unit = promise.success(true)
+}
+
+
+
+object AeroSpikeTest extends App with AeroSpikeDao {
+
+
+
+  private val namespace: String = "connekt"
+  private val binName:String = "queue"
+  private val setName:String = "pull"
+
+
+  val nodes = List("10.34.73.220","10.32.129.110")
+  implicit val aeroSpikeClient = new ConnectionProvider().createAeroSpikeConnection(nodes)
+
+  val keySimple = new Key(namespace, setName, "kinshukSimple")
+  val bin = new Bin("d", "lorem-ipsum")
+  val resSimple = Await.result(addRow(keySimple, bin ), 30.seconds )
+  println(resSimple)
+
+  println( Await.result(getRow(keySimple),30.seconds) )
+
+
+
+  val key = new Key(namespace, setName, "kinshuk1")
+  val data = Map("key" -> "value")
+  val res = Await.result(addMapRow(key, binName, data ), 30.seconds )
+  println(res)
+
+  val res2 = Await.result(getRow(key),30.seconds)
+  println(res2)
+
+
+
+}

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
@@ -37,13 +37,9 @@ trait AeroSpikeDao extends Instrumented {
 
     val data: Map[Value, Value] = values.map { case (k, v) => (new StringValue(k), new StringValue(v)) }
     val promise = Promise[Record]()
-    val record = client.operate(policy, key, MapOperation.putItems(MapPolicy.Default, binName, data.asJava))
-
-    println(record)
+    client.operate(policy,new AeroSpikeRecordHandler(promise), key, MapOperation.putItems(MapPolicy.Default, binName, data.asJava))
 
     promise.future
-
-    FastFuture.successful(new Record(Map.empty[String,AnyRef].asJava,0,0))
   }
 
   protected def deleteMapRowItems(key: Key, binName: String, keys: List[String])(implicit client: AsyncClient): Future[Record] = {
@@ -96,36 +92,3 @@ private class AeroSpikeDeleteHandler(promise: Promise[Boolean]) extends DeleteLi
 }
 
 
-
-object AeroSpikeTest extends App with AeroSpikeDao {
-
-
-
-  private val namespace: String = "connekt"
-  private val binName:String = "queue"
-  private val setName:String = "pull"
-
-
-  val nodes = List("10.34.73.220","10.32.129.110")
-  implicit val aeroSpikeClient = new ConnectionProvider().createAeroSpikeConnection(nodes)
-
-  val keySimple = new Key(namespace, setName, "kinshukSimple")
-  val bin = new Bin("d", "lorem-ipsum")
-  val resSimple = Await.result(addRow(keySimple, bin ), 30.seconds )
-  println(resSimple)
-
-  println( Await.result(getRow(keySimple),30.seconds) )
-
-
-
-  val key = new Key(namespace, setName, "kinshuk1")
-  val data = Map("key" -> "value")
-  val res = Await.result(addMapRow(key, binName, data ), 30.seconds )
-  println(res)
-
-  val res2 = Await.result(getRow(key),30.seconds)
-  println(res2)
-
-
-
-}

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/AeroSpikeDao.scala
@@ -1,25 +1,32 @@
+/*
+ *         -╥⌐⌐⌐⌐            -⌐⌐⌐⌐-
+ *      ≡╢░░░░⌐\░░░φ     ╓╝░░░░⌐░░░░╪╕
+ *     ╣╬░░`    `░░░╢┘ φ▒╣╬╝╜     ░░╢╣Q
+ *    ║╣╬░⌐        ` ╤▒▒▒Å`        ║╢╬╣
+ *    ╚╣╬░⌐        ╔▒▒▒▒`«╕        ╢╢╣▒
+ *     ╫╬░░╖    .░ ╙╨╨  ╣╣╬░φ    ╓φ░╢╢Å
+ *      ╙╢░░░░⌐"░░░╜     ╙Å░░░░⌐░░░░╝`
+ *        ``˚¬ ⌐              ˚˚⌐´
+ *
+ *      Copyright © 2016 Flipkart.com
+ */
 package com.flipkart.connekt.commons.dao
 
-import akka.http.scaladsl.util.FastFuture
 import com.aerospike.client.Value.StringValue
+import com.aerospike.client._
 import com.aerospike.client.async.AsyncClient
+import com.aerospike.client.cdt._
 import com.aerospike.client.listener.{DeleteListener, RecordListener, WriteListener}
 import com.aerospike.client.policy.WritePolicy
-import com.aerospike.client._
-import com.aerospike.client.cdt.{ListOperation, MapOperation, MapPolicy, MapReturnType}
-import com.flipkart.connekt.commons.connections.ConnectionProvider
 import com.flipkart.connekt.commons.metrics.Instrumented
 import com.flipkart.connekt.commons.services.ConnektConfig
 
-import collection.JavaConverters._
-import collection.JavaConverters._
-import scala.concurrent.{Await, Future, Promise}
-
-import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+import scala.concurrent.{Future, Promise}
 
 trait AeroSpikeDao extends Instrumented {
 
-  lazy val timeout: Int = 500 //ConnektConfig.getInt("connections.aerospike.timeout").getOrElse(500)
+  lazy val timeout: Int = ConnektConfig.getInt("connections.aerospike.timeout").getOrElse(500)
 
   protected def addRow(key: Key, bin: Bin, ttl: Option[Long] = None)(implicit client: AsyncClient): Future[Boolean] = {
     val policy = new WritePolicy()
@@ -34,22 +41,26 @@ trait AeroSpikeDao extends Instrumented {
     val policy = new WritePolicy()
     policy.timeout = timeout
     ttl.foreach(millis => policy.expiration = (millis / 1000).toInt)
-
     val data: Map[Value, Value] = values.map { case (k, v) => (new StringValue(k), new StringValue(v)) }
     val promise = Promise[Record]()
     client.operate(policy,new AeroSpikeRecordHandler(promise), key, MapOperation.putItems(MapPolicy.Default, binName, data.asJava))
-
     promise.future
   }
 
   protected def deleteMapRowItems(key: Key, binName: String, keys: List[String])(implicit client: AsyncClient): Future[Record] = {
     val policy = new WritePolicy()
     policy.timeout = timeout
-
     val _keys: List[Value] = keys.map(new StringValue(_))
-
     val promise = Promise[Record]()
     client.operate(policy, new AeroSpikeRecordHandler(promise), key, MapOperation.removeByKeyList(binName, _keys.asJava, MapReturnType.COUNT))
+    promise.future
+  }
+
+  protected def trimMapRowItems(key: Key, binName: String, numToRemove:Int)(implicit client: AsyncClient): Future[Record] = {
+    val policy = new WritePolicy()
+    policy.timeout = timeout
+    val promise = Promise[Record]()
+    client.operate(policy, new AeroSpikeRecordHandler(promise), key, MapOperation.removeByIndexRange(binName, 0, numToRemove, MapReturnType.COUNT))
     promise.future
   }
 
@@ -68,7 +79,6 @@ trait AeroSpikeDao extends Instrumented {
     client.delete(policy, new AeroSpikeDeleteHandler(promise), key)
     promise.future
   }
-
 
 }
 
@@ -90,5 +100,3 @@ private class AeroSpikeDeleteHandler(promise: Promise[Boolean]) extends DeleteLi
 
   override def onSuccess(key: Key, existed: Boolean): Unit = promise.success(true)
 }
-
-

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -25,9 +25,9 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
   private val binName:String = "queue"
   private val rowTTL = Some(15.days.toMillis)
 
-  def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Long)(implicit ec: ExecutionContext): Future[Int] = {
+  def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, expiryTs: Long)(implicit ec: ExecutionContext): Future[Int] = {
     val key = new Key(namespace, setName, s"$appName$contactIdentifier")
-    val data = Map(messageId -> s"${System.currentTimeMillis()}|$ttl" )
+    val data = Map(messageId -> s"${System.currentTimeMillis()}|$expiryTs" )
     addMapRow(key, binName, data, rowTTL).map { _record =>
       _record.getInt(binName)
     }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -49,7 +49,7 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
     getQueue(appName, contactIdentifier).flatMap {
       case m if m.isEmpty => FastFuture.successful(0)
       case less if less.size <= numToRemove =>
-        deleteMapRowItems(key, binName, less.keys.toList).map(_ => 0)
+        deleteRow(key).map(_ => 0)
       case normal =>
         val sortedMessageIds = normal.toSeq.sortBy { case (_, data) => data.split('|').head.toLong }
         val mIds = sortedMessageIds.take(numToRemove).map { case (messageId, _) => messageId }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -16,8 +16,8 @@ import com.aerospike.client.Key
 import com.aerospike.client.async.AsyncClient
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 class MessageQueueDao(private val setName: String, private implicit val client: AsyncClient) extends Dao with AeroSpikeDao {
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -23,11 +23,12 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
 
   private val namespace: String = "connekt"
   private val binName:String = "queue"
+  private val rowTTL = Some(15.days.toMillis)
 
   def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Long)(implicit ec: ExecutionContext): Future[Int] = {
     val key = new Key(namespace, setName, s"$appName$contactIdentifier")
     val data = Map(messageId -> s"${System.currentTimeMillis()}|$ttl" )
-    addMapRow(key, binName, data, Some(1.days.toMillis)).map {  _record =>  //Row TTL: 15days, if no future writes happens on this row
+    addMapRow(key, binName, data, rowTTL).map { _record =>
       _record.getInt(binName)
     }
   }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -1,34 +1,25 @@
 package com.flipkart.connekt.commons.dao
 
-import com.aerospike.client.{Bin, Key}
+import com.aerospike.client.Key
 import com.aerospike.client.async.AsyncClient
 
-import collection.JavaConverters._
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
 
 class MessageQueueDao(private val setName: String, private implicit val client: AsyncClient) extends Dao with AeroSpikeDao {
 
   private val namespace: String = "connekt"
   private val binName:String = "queue"
 
-
-  def test(): Unit ={
-    val key = new Key(namespace, setName, "kinshuk")
-    val data = Map("key" -> "value")
-    val res = Await.result(addMapRow(key, binName, data ), 30.seconds )
-    println(res)
-
-    val res2 = Await.result(getRow(key),30.seconds)
-    println(res2)
-
-
-  }
-
   def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Long): Future[_] = {
     val key = new Key(namespace, setName, s"$appName$contactIdentifier")
-    val data = Map(messageId  ->  s"${System.currentTimeMillis()}|$ttl" )
+    val data = Map(messageId -> s"${System.currentTimeMillis()}|$ttl" )
     addMapRow(key, binName, data )
+  }
+
+  def removeMessage(appName: String, contactIdentifier: String, messageId: String): Future[_] = {
+    val key = new Key(namespace, setName, s"$appName$contactIdentifier")
+    deleteMapRowItems(key, binName, List(messageId))
   }
 
   def getMessages(appName: String, contactIdentifier: String, timestampRange: Option[(Long, Long)])(implicit ec: ExecutionContext): Future[List[String]] = {
@@ -39,7 +30,8 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
           data.toString.split('|').last.toLong >= System.currentTimeMillis()
         }
 
-        deleteMapRowItems(key,binName,expired.keys.map(_.toString).toList )
+        if(expired.nonEmpty)
+          deleteMapRowItems(key,binName,expired.keys.map(_.toString).toList )
 
         if(timestampRange.isDefined){
           val timeFiltered = valid.filter { case (_ , data ) =>
@@ -49,10 +41,8 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
           timeFiltered.keys.map(_.toString).toList
         } else
           valid.keys.map(_.toString).toList
-
       } getOrElse List.empty
     }
   }
-
 
 }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -20,6 +20,17 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
+sealed case class MessageMetaData(createTs:Long, expiryTs:Long) {
+  def encoded:String = s"$createTs|$expiryTs"
+}
+
+private object MessageMetaData {
+  def apply(encoded:String): MessageMetaData = {
+    val parts = encoded.split('|').map(_.toLong)
+    MessageMetaData(parts.head, parts.last)
+  }
+}
+
 class MessageQueueDao(private val setName: String, private implicit val client: AsyncClient) extends Dao with AeroSpikeDao {
 
   private val namespace: String = "connekt"
@@ -28,7 +39,7 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
 
   def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, expiryTs: Long)(implicit ec: ExecutionContext): Future[Int] = {
     val key = new Key(namespace, setName, s"$appName$contactIdentifier")
-    val data = Map(messageId -> s"${System.currentTimeMillis()}|$expiryTs")
+    val data = Map(messageId -> MessageMetaData(System.currentTimeMillis(),expiryTs).encoded)
     addMapRow(key, binName, data, rowTTL).map { _record =>
       _record.getInt(binName)
     }
@@ -51,23 +62,25 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
       case less if less.size <= numToRemove =>
         deleteRow(key).map(_ => 0)
       case normal =>
-        val sortedMessageIds = normal.toSeq.sortBy { case (_, data) => data.split('|').head.toLong }
+        val sortedMessageIds = normal.toSeq.sortBy { case (_, metadata) => metadata.createTs }
         val mIds = sortedMessageIds.take(numToRemove).map { case (messageId, _) => messageId }
         deleteMapRowItems(key, binName, mIds.toList).map(_ => normal.size - numToRemove)
     }
   }
 
-  private def getQueue(appName: String, contactIdentifier: String)(implicit ec: ExecutionContext): Future[Map[String, String]] = {
+  private def getQueue(appName: String, contactIdentifier: String)(implicit ec: ExecutionContext): Future[Map[String, MessageMetaData]] = {
     val key = new Key(namespace, setName, s"$appName$contactIdentifier")
     getRow(key).map { _record =>
       Option(_record).map { record =>
-        val (valid, expired) = record.getMap(binName).asScala.toMap.asInstanceOf[Map[String,String]].partition { case (_, data) =>
-          data.split('|').last.toLong >= System.currentTimeMillis()
+        val (valid, expired) = record.getMap(binName).asScala.toMap.asInstanceOf[Map[String,String]].map{ case (messageId, encodedMetaData) =>
+          messageId -> MessageMetaData(encodedMetaData)
+        }.partition { case (_, metadata) =>
+          metadata.expiryTs >= System.currentTimeMillis()
         }
         if (expired.nonEmpty)
           deleteMapRowItems(key, binName, expired.keys.toList)
         valid
-      } getOrElse Map.empty[String, String]
+      } getOrElse Map.empty[String, MessageMetaData]
     }
   }
 
@@ -79,13 +92,12 @@ class MessageQueueDao(private val setName: String, private implicit val client: 
     getQueue(appName, contactIdentifier).map { _messages =>
       val messages = timestampRange match {
         case Some((fromTs, endTs)) =>
-          _messages.filter { case (_, data) =>
-            val createTs = data.split('|').head.toLong
-            createTs >= fromTs && createTs <= endTs
+          _messages.filter { case (_, metadata) =>
+            metadata.createTs >= fromTs && metadata.createTs <= endTs
           }
         case None => _messages
       }
-      messages.toSeq.sortWith(_._2.split('|').head.toLong > _._2.split('|').head.toLong).map(_._1)
+      messages.toSeq.sortWith(_._2.createTs > _._2.createTs).map(_._1)
     }
   }
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/dao/MessageQueueDao.scala
@@ -1,0 +1,58 @@
+package com.flipkart.connekt.commons.dao
+
+import com.aerospike.client.{Bin, Key}
+import com.aerospike.client.async.AsyncClient
+
+import collection.JavaConverters._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class MessageQueueDao(private val setName: String, private implicit val client: AsyncClient) extends Dao with AeroSpikeDao {
+
+  private val namespace: String = "connekt"
+  private val binName:String = "queue"
+
+
+  def test(): Unit ={
+    val key = new Key(namespace, setName, "kinshuk")
+    val data = Map("key" -> "value")
+    val res = Await.result(addMapRow(key, binName, data ), 30.seconds )
+    println(res)
+
+    val res2 = Await.result(getRow(key),30.seconds)
+    println(res2)
+
+
+  }
+
+  def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Long): Future[_] = {
+    val key = new Key(namespace, setName, s"$appName$contactIdentifier")
+    val data = Map(messageId  ->  s"${System.currentTimeMillis()}|$ttl" )
+    addMapRow(key, binName, data )
+  }
+
+  def getMessages(appName: String, contactIdentifier: String, timestampRange: Option[(Long, Long)])(implicit ec: ExecutionContext): Future[List[String]] = {
+    val key = new Key(namespace, setName, s"$appName$contactIdentifier")
+    getRow(key).map { _record =>
+      Option(_record).map { record =>
+        val (valid, expired) = record.getMap(binName).asScala.partition { case (_ , data) =>
+          data.toString.split('|').last.toLong >= System.currentTimeMillis()
+        }
+
+        deleteMapRowItems(key,binName,expired.keys.map(_.toString).toList )
+
+        if(timestampRange.isDefined){
+          val timeFiltered = valid.filter { case (_ , data ) =>
+            val ts =  data.toString.split('|').head.toLong
+            ts >= timestampRange.get._1 && ts <= timestampRange.get._2
+          }
+          timeFiltered.keys.map(_.toString).toList
+        } else
+          valid.keys.map(_.toString).toList
+
+      } getOrElse List.empty
+    }
+  }
+
+
+}

--- a/commons/src/main/scala/com/flipkart/connekt/commons/factories/ServiceFactory.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/factories/ServiceFactory.scala
@@ -64,6 +64,10 @@ object ServiceFactory {
     serviceCache += ServiceType.SCHEDULER -> instance
   }
 
+  def initMessageQueueService(dao: MessageQueueDao):Unit = {
+    serviceCache += ServiceType.PULL_QUEUE -> new MessageQueueService(dao)
+  }
+
   def getMessageService(channel: Channel): TMessageService = {
     channel match {
       case Channel.PUSH => serviceCache(ServiceType.PN_MESSAGE).asInstanceOf[TMessageService]
@@ -71,6 +75,8 @@ object ServiceFactory {
       case Channel.SMS => serviceCache(ServiceType.SMS_MESSAGE).asInstanceOf[TMessageService]
     }
   }
+
+  def getMessageQueueService = serviceCache(ServiceType.PULL_QUEUE).asInstanceOf[MessageQueueService]
 
   def initStencilService(dao: TStencilDao) = serviceCache += ServiceType.STENCIL -> new StencilService(dao)
 
@@ -93,5 +99,5 @@ object ServiceFactory {
 }
 
 object ServiceType extends Enumeration {
-  val PN_MESSAGE, TEMPLATE, CALLBACK, USER_INFO, AUTHORISATION, KEY_CHAIN, STATS_REPORTING, SCHEDULER, STENCIL, SMS_MESSAGE, EMAIL_MESSAGE, APP_CONFIG = Value
+  val PN_MESSAGE, TEMPLATE, CALLBACK, USER_INFO, AUTHORISATION, KEY_CHAIN, STATS_REPORTING, SCHEDULER, STENCIL, SMS_MESSAGE, EMAIL_MESSAGE, APP_CONFIG, PULL_QUEUE = Value
 }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/services/MessageQueueService.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/services/MessageQueueService.scala
@@ -1,0 +1,18 @@
+package com.flipkart.connekt.commons.services
+
+import com.flipkart.connekt.commons.dao.DaoFactory
+import com.flipkart.connekt.commons.metrics.Instrumented
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+object MessageQueueService extends Instrumented {
+
+  private lazy val pullDao = DaoFactory.getMessageQueueDao
+  private val defaultTTL =  7.days.toMillis
+
+  def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Option[Long]): Future[_] = pullDao.enqueueMessage(appName, contactIdentifier, messageId, ttl.getOrElse(System.currentTimeMillis() + defaultTTL))
+
+  def getMessages(appName: String, contactIdentifier: String, timestampRange: Option[(Long, Long)])(implicit ec: ExecutionContext): Future[List[String]] = pullDao.getMessages(appName,contactIdentifier, timestampRange)(ec)
+
+}

--- a/commons/src/main/scala/com/flipkart/connekt/commons/services/MessageQueueService.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/services/MessageQueueService.scala
@@ -35,8 +35,10 @@ class MessageQueueService(dao: MessageQueueDao) extends TService with Instrument
     }
   }
 
+  def empty(appName: String, contactIdentifier: String ): Future[_] = dao.empty(appName.toLowerCase, contactIdentifier)
+
   def removeMessage(appName: String, contactIdentifier: String, messageId: String): Future[_] = dao.removeMessage(appName.toLowerCase, contactIdentifier, messageId)
 
-  def getMessages(appName: String, contactIdentifier: String, timestampRange: Option[(Long, Long)])(implicit ec: ExecutionContext): Future[List[String]] = dao.getMessages(appName.toLowerCase, contactIdentifier, timestampRange)(ec)
+  def getMessages(appName: String, contactIdentifier: String, timestampRange: Option[(Long, Long)])(implicit ec: ExecutionContext): Future[Seq[String]] = dao.getMessages(appName.toLowerCase, contactIdentifier, timestampRange)(ec)
 
 }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/services/MessageQueueService.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/services/MessageQueueService.scala
@@ -11,7 +11,9 @@ object MessageQueueService extends Instrumented {
   private lazy val pullDao = DaoFactory.getMessageQueueDao
   private val defaultTTL =  7.days.toMillis
 
-  def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Option[Long]): Future[_] = pullDao.enqueueMessage(appName, contactIdentifier, messageId, ttl.getOrElse(System.currentTimeMillis() + defaultTTL))
+  def enqueueMessage(appName: String, contactIdentifier: String, messageId: String, ttl: Option[Long] = None): Future[_] = pullDao.enqueueMessage(appName.toLowerCase, contactIdentifier, messageId, ttl.getOrElse(System.currentTimeMillis() + defaultTTL))
+
+  def removeMessage(appName: String, contactIdentifier: String, messageId: String): Future[_] = pullDao.removeMessage(appName, contactIdentifier, messageId)
 
   def getMessages(appName: String, contactIdentifier: String, timestampRange: Option[(Long, Long)])(implicit ec: ExecutionContext): Future[List[String]] = pullDao.getMessages(appName,contactIdentifier, timestampRange)(ec)
 

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/CommonsBaseTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/CommonsBaseTest.scala
@@ -65,6 +65,10 @@ class CommonsBaseTest extends ConnektUTSpec {
     val couchbaseCf = ConnektConfig.getConfig("connections.couchbase").getOrElse(ConfigFactory.empty())
     DaoFactory.initCouchbaseCluster(couchbaseCf)
 
+    val aeroSpikeCf = ConnektConfig.getConfig("connections.aerospike").getOrElse(ConfigFactory.empty())
+    DaoFactory.initAeroSpike(aeroSpikeCf)
+
+
     DaoFactory.initReportingDao(DaoFactory.getCouchbaseBucket("StatsReporting"))
 
     ServiceFactory.initPNMessageService(DaoFactory.getPNRequestDao, DaoFactory.getUserConfigurationDao, getKafkaProducerHelper, getKafkaConsumerConf, null)

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/connections/MockConnectionProvider.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/connections/MockConnectionProvider.scala
@@ -15,19 +15,23 @@ package com.flipkart.connekt.commons.tests.connections
 import java.util.Properties
 import javax.sql.DataSource
 
+import com.aerospike.client.Host
+import com.aerospike.client.async.{AsyncClient, AsyncClientPolicy}
 import com.couchbase.client.java.Cluster
 import com.flipkart.connekt.commons.connections.TConnectionProvider
 import com.flipkart.connekt.commons.tests.connections.couchbase.CouchbaseMockCluster
 import org.apache.commons.dbcp2.BasicDataSourceFactory
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.hbase.client.{HConnectionManager, HConnection}
+import org.apache.hadoop.hbase.client.{HConnection, HConnectionManager}
 
-class MockConnectionProvider extends TConnectionProvider{
+class MockConnectionProvider extends TConnectionProvider {
 
   override def createCouchBaseConnection(nodes: List[String]): Cluster = new CouchbaseMockCluster
 
   override def createHbaseConnection(hConnConfig: Configuration): HConnection = HConnectionManager.createConnection(hConnConfig)
 
   override def createDatasourceConnection(mySQLProperties: Properties): DataSource = BasicDataSourceFactory.createDataSource(mySQLProperties)
+
+  override def createAeroSpikeConnection(nodes: List[String]): AsyncClient =  new AsyncClient(new AsyncClientPolicy(), nodes.map(new Host(_, 3000)): _ *)
 
 }

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -43,17 +43,23 @@ class MessageQueueDaoTest extends CommonsBaseTest {
 
     fetch.size shouldEqual 10
 
-
     println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
     println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
     println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
     println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
-
 
     val fetch2 = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
     println(fetch2)
-
     fetch2.size shouldEqual 2
+
+    println(Await.result( dao.trimMessages("testApp",contactId, 5), 30.seconds))
+    val fetch3 = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
+    println(fetch3)
+
+    fetch3.size shouldEqual 0
+
+    Await.result(dao.trimMessages("testApp",contactId, 5), 30.seconds)
+    Await.result(dao.getMessages("testApp",contactId, None), 30.seconds).size shouldEqual 0
 
   }
 

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -24,7 +24,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class MessageQueueDaoTest extends CommonsBaseTest {
 
-  private val contactId = "cae73a32-cc99-429e-b024-aab8aeob5"
+  private val contactId = UUID.randomUUID().toString
   private lazy val dao = DaoFactory.getMessageQueueDao
 
   override def beforeAll() = {
@@ -39,10 +39,9 @@ class MessageQueueDaoTest extends CommonsBaseTest {
     )
 
     val fetch = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
-    println(fetch.size)
     println(fetch)
 
-    fetch.nonEmpty shouldEqual true
+    fetch.size shouldEqual 10
 
 
     println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
@@ -51,8 +50,10 @@ class MessageQueueDaoTest extends CommonsBaseTest {
     println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
 
 
-    println(Await.result( dao.getMessages("testApp",contactId, None), 30.seconds))
+    val fetch2 = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
+    println(fetch2)
 
+    fetch2.size shouldEqual 2
 
   }
 

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -34,9 +34,10 @@ class MessageQueueDaoTest extends CommonsBaseTest {
   "PullMessageDao test" should "add data" in {
     val expiry = System.currentTimeMillis() + 5.minutes.toMillis
 
-    11 to 20 foreach( i =>
-      noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, StringUtils.generateRandomStr(6) + i.toString, expiry), 30.seconds)
-    )
+    11 to 20 foreach { i =>
+      Thread.sleep(1)
+      noException should be thrownBy Await.result(dao.enqueueMessage("testApp", contactId, StringUtils.generateRandomStr(6) + i.toString, expiry), 30.seconds)
+    }
 
     val fetch = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
     println(fetch)

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -1,0 +1,52 @@
+/*
+ *         -╥⌐⌐⌐⌐            -⌐⌐⌐⌐-
+ *      ≡╢░░░░⌐\░░░φ     ╓╝░░░░⌐░░░░╪╕
+ *     ╣╬░░`    `░░░╢┘ φ▒╣╬╝╜     ░░╢╣Q
+ *    ║╣╬░⌐        ` ╤▒▒▒Å`        ║╢╬╣
+ *    ╚╣╬░⌐        ╔▒▒▒▒`«╕        ╢╢╣▒
+ *     ╫╬░░╖    .░ ╙╨╨  ╣╣╬░φ    ╓φ░╢╢Å
+ *      ╙╢░░░░⌐"░░░╜     ╙Å░░░░⌐░░░░╝`
+ *        ``˚¬ ⌐              ˚˚⌐´
+ *
+ *      Copyright © 2016 Flipkart.com
+ */
+package com.flipkart.connekt.commons.tests.dao
+
+import java.util.UUID
+
+import com.flipkart.connekt.commons.dao.DaoFactory
+import com.flipkart.connekt.commons.tests.CommonsBaseTest
+
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MessageQueueDaoTest extends CommonsBaseTest {
+
+  private val contactId = "cae73a32-cc99-429e-b024-dab81eaa6"
+  private lazy val dao = DaoFactory.getMessageQueueDao
+
+
+  override def beforeAll() = {
+    super.beforeAll()
+  }
+
+  "PullMessageDao test" should "add data" in {
+    val expiry = System.currentTimeMillis() + 60000
+
+    dao.test()
+
+    1 to 10 foreach( i =>
+      noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, UUID.randomUUID().toString, expiry), 30.seconds)
+    )
+
+    val fetch = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
+    println(fetch.size)
+    println(fetch)
+
+    fetch.nonEmpty shouldEqual true
+
+  }
+
+
+}

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -16,6 +16,7 @@ import java.util.UUID
 
 import com.flipkart.connekt.commons.dao.DaoFactory
 import com.flipkart.connekt.commons.tests.CommonsBaseTest
+import com.flipkart.connekt.commons.utils.StringUtils
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -23,9 +24,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class MessageQueueDaoTest extends CommonsBaseTest {
 
-  private val contactId = "cae73a32-cc99-429e-b024-dab81eaa5"
+  private val contactId = "cae73a32-cc99-429e-b024-aab8aeob5"
   private lazy val dao = DaoFactory.getMessageQueueDao
-
 
   override def beforeAll() = {
     super.beforeAll()
@@ -34,8 +34,8 @@ class MessageQueueDaoTest extends CommonsBaseTest {
   "PullMessageDao test" should "add data" in {
     val expiry = System.currentTimeMillis() + 5.minutes.toMillis
 
-    1 to 10 foreach( i =>
-      noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, i.toString, expiry), 30.seconds)
+    11 to 20 foreach( i =>
+      noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, StringUtils.generateRandomStr(6) + i.toString, expiry), 30.seconds)
     )
 
     val fetch = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class MessageQueueDaoTest extends CommonsBaseTest {
 
-  private val contactId = "cae73a32-cc99-429e-b024-dab81eaa6"
+  private val contactId = "cae73a32-cc99-429e-b024-dab81eaa5"
   private lazy val dao = DaoFactory.getMessageQueueDao
 
 
@@ -35,7 +35,7 @@ class MessageQueueDaoTest extends CommonsBaseTest {
     val expiry = System.currentTimeMillis() + 5.minutes.toMillis
 
     1 to 10 foreach( i =>
-      noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, UUID.randomUUID().toString, expiry), 30.seconds)
+      noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, i.toString, expiry), 30.seconds)
     )
 
     val fetch = Await.result( dao.getMessages("testApp",contactId, None), 30.seconds)
@@ -43,6 +43,16 @@ class MessageQueueDaoTest extends CommonsBaseTest {
     println(fetch)
 
     fetch.nonEmpty shouldEqual true
+
+
+    println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
+    println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
+    println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
+    println(Await.result( dao.trimMessages("testApp",contactId, 2), 30.seconds))
+
+
+    println(Await.result( dao.getMessages("testApp",contactId, None), 30.seconds))
+
 
   }
 

--- a/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
+++ b/commons/src/test/scala/com/flipkart/connekt/commons/tests/dao/MessageQueueDaoTest.scala
@@ -32,9 +32,7 @@ class MessageQueueDaoTest extends CommonsBaseTest {
   }
 
   "PullMessageDao test" should "add data" in {
-    val expiry = System.currentTimeMillis() + 60000
-
-    dao.test()
+    val expiry = System.currentTimeMillis() + 5.minutes.toMillis
 
     1 to 10 foreach( i =>
       noException should be thrownBy Await.result(dao.enqueueMessage("testApp",contactId, UUID.randomUUID().toString, expiry), 30.seconds)

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/ReceptorsBoot.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/ReceptorsBoot.scala
@@ -56,6 +56,9 @@ object ReceptorsBoot extends BaseApp {
       val couchbaseCf = ConnektConfig.getConfig("connections.couchbase").getOrElse(ConfigFactory.empty())
       DaoFactory.initCouchbaseCluster(couchbaseCf)
 
+      val aeroSpikeCf = ConnektConfig.getConfig("connections.aerospike").getOrElse(ConfigFactory.empty())
+      DaoFactory.initAeroSpike(aeroSpikeCf)
+
       DaoFactory.initReportingDao(DaoFactory.getCouchbaseBucket("StatsReporting"))
 
       val kafkaConnConf = ConnektConfig.getConfig("connections.kafka.producerConnProps").getOrElse(ConfigFactory.empty())

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/ReceptorsBoot.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/ReceptorsBoot.scala
@@ -65,6 +65,7 @@ object ReceptorsBoot extends BaseApp {
       val kafkaProducerPoolConf = ConnektConfig.getConfig("connections.kafka.producerPool").getOrElse(ConfigFactory.empty())
       val kafkaProducerHelper = KafkaProducerHelper.init(kafkaConnConf, kafkaProducerPoolConf)
 
+      ServiceFactory.initMessageQueueService(DaoFactory.getMessageQueueDao)
       ServiceFactory.initSchedulerService(DaoFactory.getHTableFactory.getConnection)
       ServiceFactory.initPNMessageService(DaoFactory.getPNRequestDao, DaoFactory.getUserConfigurationDao, kafkaProducerHelper, kafkaConnConf, ServiceFactory.getSchedulerService)
       ServiceFactory.initSMSMessageService(DaoFactory.getSmsRequestDao, DaoFactory.getUserConfigurationDao, kafkaProducerHelper, kafkaConnConf, null)

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/FetchRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/FetchRoute.scala
@@ -20,54 +20,51 @@ import com.flipkart.connekt.commons.entities.Channel
 import com.flipkart.connekt.commons.entities.MobilePlatform.MobilePlatform
 import com.flipkart.connekt.commons.factories.ServiceFactory
 import com.flipkart.connekt.commons.iomodels._
-import com.flipkart.connekt.commons.services.ConnektConfig
+import com.flipkart.connekt.commons.services.MessageQueueService
 import com.flipkart.connekt.commons.utils.StringUtils._
 import com.flipkart.connekt.receptors.directives.MPlatformSegment
 import com.flipkart.connekt.receptors.routes.BaseJsonHandler
 import com.flipkart.connekt.receptors.wire.ResponseUtils._
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
 
 
 class FetchRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
 
-  val seenEventTypes = ConnektConfig.getList[String]("core.pn.seen.events").map(_.toLowerCase)
+  private implicit val ioDispatcher = am.getSystem.dispatchers.lookup("akka.actor.route-blocking-dispatcher")
 
-  implicit val ioDispatcher = am.getSystem.dispatchers.lookup("akka.actor.route-blocking-dispatcher")
-
-  lazy implicit val stencilService = ServiceFactory.getStencilService
+  private lazy implicit val stencilService = ServiceFactory.getStencilService
+  private lazy val messageService = ServiceFactory.getMessageService(Channel.PUSH)
 
   val route =
     authenticate {
       user =>
         pathPrefix("v1") {
-          path("fetch" / "push" / MPlatformSegment / Segment / Segment) {
+          pathPrefix("fetch" / "push" / MPlatformSegment / Segment / Segment) {
             (platform: MobilePlatform, appName: String, instanceId: String) =>
-              authorize(user, "FETCH", s"FETCH_$appName") {
-                get {
-                  parameters('startTs.as[Long], 'endTs ? System.currentTimeMillis, 'skipIds.*) {(startTs, endTs, skipIds) =>
-                    complete {
-                      Future {
-                        profile(s"fetch.$platform.$appName") {
+              pathEndOrSingleSlash {
+                authorize(user, "FETCH", s"FETCH_$appName") {
+                  get {
+                    parameters('startTs.as[Long], 'endTs ? System.currentTimeMillis, 'skipIds.*) { (startTs, endTs, skipIds) =>
 
-                          require(startTs < endTs, "startTs must be prior to endTs")
+                      require(startTs < endTs, "startTs must be prior to endTs")
 
-                          val safeStartTs = if(startTs < (System.currentTimeMillis - 7.days.toMillis)) System.currentTimeMillis - 1.days.toMillis else startTs
-                          val requestEvents = ServiceFactory.getCallbackService.fetchCallbackEventByContactId(s"${appName.toLowerCase}$instanceId", Channel.PUSH, safeStartTs + 1, endTs)
-                          val messageService = ServiceFactory.getMessageService(Channel.PUSH)
+                      val profiler = timer(s"fetch.$platform.$appName").time()
 
-                          //Skip all messages which are either read/dismissed or passed in skipIds
-                          val skipMessageIds: Set[String] = skipIds.toSet ++ requestEvents.map(res => res.map(_._1.asInstanceOf[PNCallbackEvent]).filter(e => seenEventTypes.contains(e.eventType.toLowerCase)).map(_.messageId)).get.toSet
-                          val messages: Try[List[ConnektRequest]] = requestEvents.map(res => {
-                            val messageIds: List[String] = res.map(_._1.asInstanceOf[PNCallbackEvent]).map(_.messageId).distinct
-                            val filteredMessageIds: List[String] = messageIds.filterNot(skipMessageIds.contains)
-                            val fetchedMessages: Try[List[ConnektRequest]] = messageService.getRequestInfo(filteredMessageIds)
-                            fetchedMessages.map(_.filter(_.expiryTs.forall(_ >= System.currentTimeMillis)).filterNot(_.isTestRequest)).getOrElse(List.empty[ConnektRequest])
-                          })
+                      val skipMessageIds: Set[String] = skipIds.toSet
+                      val safeStartTs = if (startTs < (System.currentTimeMillis - 7.days.toMillis)) System.currentTimeMillis - 1.days.toMillis else startTs
 
-                          val pushRequests = messages.get.map(r => {
+                      val pendingMessageIds = MessageQueueService.getMessages(appName, instanceId, Some(Tuple2(safeStartTs + 1, endTs)))
+
+                      complete {
+                        pendingMessageIds.map(_ids => {
+                          val filteredMessageIds: List[String] = _ids.distinct.filterNot(skipMessageIds.contains)
+
+                          val fetchedMessages: Try[List[ConnektRequest]] = messageService.getRequestInfo(filteredMessageIds)
+                          val messages = fetchedMessages.map(_.filter(_.expiryTs.forall(_ >= System.currentTimeMillis)).filterNot(_.isTestRequest)).getOrElse(List.empty[ConnektRequest])
+
+                          val pushRequests = messages.map(r => {
                             r.id -> {
                               val channelData = Option(r.channelData) match {
                                 case Some(PNRequestData(_, pnData)) if pnData != null => r.channelData
@@ -83,14 +80,20 @@ class FetchRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
                             case Some(stencil) => stencilService.materialize(stencil, pushRequests.getJsonNode)
                           }
 
-                          val finalTs = requestEvents.getOrElse(List.empty[(CallbackEvent, Long)]).map(_._2).reduceLeftOption(_ max _).getOrElse(endTs)
-
+                          profiler.stop()
                           GenericResponse(StatusCodes.OK.intValue, null, Response(s"Fetched result for $instanceId", transformedRequests))
-                            .respondWithHeaders(scala.collection.immutable.Seq(RawHeader("endTs", finalTs.toString), RawHeader("Access-Control-Expose-Headers", "endTs")))
-                        }
-                      }(ioDispatcher)
+                            .respondWithHeaders(scala.collection.immutable.Seq(RawHeader("endTs", endTs.toString), RawHeader("Access-Control-Expose-Headers", "endTs")))
+
+                        })(ioDispatcher)
+
+                      }
                     }
                   }
+                }
+              } ~ path(Segment) { messageId: String =>
+                delete {
+                  MessageQueueService.removeMessage(appName, instanceId, messageId)
+                  complete(GenericResponse(StatusCodes.OK.intValue, null, Response(s"Removed $messageId from $appName / $instanceId", null)))
                 }
               }
           }


### PR DESCRIPTION
This changeset moves away from using hbase scan to using per appName-contactId queue (backed by aerospike). This also builds support for generic pull notification which was being attempted in #169 

**DataStructure** : 
Underlying storage in Aerospike is Map. Data is Stored as  `messageId -> (createTs, expiryTs)`. When new messages are added they are atomically added to this Map. When size of this total map reaches maxLimit, a trim is triggered which cleans up 10% (configurable) of space using FIFO policy.

While fetching for entries, expired entries are filtered and removed from the Map. Incase no fetch happens, it will grow till it hits the maxLimit and then trim will triggered on next write. 

If there are no operations for a particular entry after 15days (configurable) the row will get auto-purged.

**AutoRemoval of entries when delivery confirmed** : When a callback is received which corresponds to a seen/delivered event, those messageId entries are removed from the Map 

**Selective Removal** : Incase any particular notification need to be removed from queue, the same can be done using the delete api