### PR TITLE
Email address validation in Connekt while accepting requests

### DIFF
--- a/commons/src/main/scala/com/flipkart/connekt/commons/entities/exception/ExceptionType.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/entities/exception/ExceptionType.scala
@@ -1,0 +1,20 @@
+/*
+ *         -╥⌐⌐⌐⌐            -⌐⌐⌐⌐-
+ *      ≡╢░░░░⌐\░░░φ     ╓╝░░░░⌐░░░░╪╕
+ *     ╣╬░░`    `░░░╢┘ φ▒╣╬╝╜     ░░╢╣Q
+ *    ║╣╬░⌐        ` ╤▒▒▒Å`        ║╢╬╣
+ *    ╚╣╬░⌐        ╔▒▒▒▒`«╕        ╢╢╣▒
+ *     ╫╬░░╖    .░ ╙╨╨  ╣╣╬░φ    ╓φ░╢╢Å
+ *      ╙╢░░░░⌐"░░░╜     ╙Å░░░░⌐░░░░╝`
+ *        ``˚¬ ⌐              ˚˚⌐´
+ *
+ *      Copyright © 2016 Flipkart.com
+ */
+package com.flipkart.connekt.commons.entities.exception
+
+object ExceptionType extends Enumeration {
+
+  type ExceptionType = Value
+  val BAD_REQUEST_INVALID_EMAIL, BAD_REQUEST_INVALID_NAME, SERVICE_FAILURE = Value
+
+}

--- a/commons/src/main/scala/com/flipkart/connekt/commons/entities/exception/ServiceException.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/entities/exception/ServiceException.scala
@@ -1,0 +1,22 @@
+/*
+ *         -╥⌐⌐⌐⌐            -⌐⌐⌐⌐-
+ *      ≡╢░░░░⌐\░░░φ     ╓╝░░░░⌐░░░░╪╕
+ *     ╣╬░░`    `░░░╢┘ φ▒╣╬╝╜     ░░╢╣Q
+ *    ║╣╬░⌐        ` ╤▒▒▒Å`        ║╢╬╣
+ *    ╚╣╬░⌐        ╔▒▒▒▒`«╕        ╢╢╣▒
+ *     ╫╬░░╖    .░ ╙╨╨  ╣╣╬░φ    ╓φ░╢╢Å
+ *      ╙╢░░░░⌐"░░░╜     ╙Å░░░░⌐░░░░╝`
+ *        ``˚¬ ⌐              ˚˚⌐´
+ *
+ *      Copyright © 2016 Flipkart.com
+ */
+package com.flipkart.connekt.commons.entities.exception
+
+import akka.http.javadsl.model.{StatusCode, StatusCodes}
+import com.flipkart.connekt.commons.entities.exception.ExceptionType.ExceptionType
+
+case class ServiceException(statusCode : StatusCode = StatusCodes.ACCEPTED,
+                            exceptionType: ExceptionType = ExceptionType.SERVICE_FAILURE,
+                            private val message: String = "",
+                            private val cause: Throwable = None.orNull)
+  extends Exception(message, cause)

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailCallbackEvent.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailCallbackEvent.scala
@@ -13,12 +13,10 @@
 package com.flipkart.connekt.commons.iomodels
 
 import com.flipkart.connekt.commons.dao.HbaseSinkSupport
-import com.flipkart.connekt.commons.entities.Channel
 import com.flipkart.connekt.commons.entities.bigfoot.PublishSupport
-import com.flipkart.connekt.commons.factories.ServiceFactory
 import com.flipkart.connekt.commons.utils.DateTimeUtils
-import org.apache.commons.lang.RandomStringUtils
 import com.flipkart.connekt.commons.utils.StringUtils._
+import org.apache.commons.lang.RandomStringUtils
 
 case class EmailCallbackEvent(messageId: String,
                               clientId: String,

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -34,7 +34,7 @@ case class EmailRequestInfo(@JsonProperty(required = false) appName: String,
     )
   }
 
-  def validateEmailRequestInfo(): Unit = {
+  def validate(): Unit = {
     val emailAddresses = (to ++ cc ++ bcc).+(from).+(replyTo).filter(e => null != e.address && e.address.nonEmpty)
     val invalidCharacters = ConnektConfig.getList[String]("invalid.email.name.characters").toSet
     emailAddresses.foreach(e => {

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -58,7 +58,7 @@ case class EmailAddress(name: String, address: String) {
     }
     val invalidCharacters = ConnektConfig.getList[String]("email.name.invalid.characters").toSet //fetched by config
     invalidCharacters.foreach(i => {
-      if (name.contains(i)) {
+      if (name != null && name.contains(i)) { // null check to make sure 'null's are passed as current bau
         throw ServiceException(StatusCodes.BAD_REQUEST, ExceptionType.BAD_REQUEST_INVALID_NAME, s"Bad Request. Invalid email name - $name")
       }
     })

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -35,14 +35,14 @@ case class EmailRequestInfo(@JsonProperty(required = false) appName: String,
   }
 
   def validateEmailRequestInfo(): Unit = {
-    val recepients = (to ++ cc ++ bcc).+(from).+(replyTo).filter(e => null != e.address && e.address.nonEmpty)
+    val emailAddresses = (to ++ cc ++ bcc).+(from).+(replyTo).filter(e => null != e.address && e.address.nonEmpty)
     val invalidCharacters = ConnektConfig.getList[String]("invalid.email.name.characters").toSet
-    recepients.foreach(e => {
+    emailAddresses.foreach(e => {
       require(!EmailValidator.getInstance().isValid(e.address), s"Bad Request. Invalid email address - ${e.address}")
     })
     invalidCharacters.foreach(i => {
-      recepients.foreach(r => {
-        require(r.name.contains(i), s"Bad Request. Invalid email name - ${r.name}")
+      emailAddresses.foreach(e => {
+        require(e.name.contains(i), s"Bad Request. Invalid email name - ${e.name}")
       })
     })
   }

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -36,7 +36,7 @@ case class EmailRequestInfo(@JsonProperty(required = false) appName: String,
 
   def validateEmailRequestInfo(): Unit = {
     val recepients = (to ++ cc ++ bcc).+(from).+(replyTo).filter(e => null != e.address && e.address.nonEmpty)
-    val invalidCharacters = ConnektConfig.getList[String]("invalid.email.name.character").toSet
+    val invalidCharacters = ConnektConfig.getList[String]("invalid.email.name.characters").toSet
     recepients.foreach(e => {
       require(!EmailValidator.getInstance().isValid(e.address), s"Bad Request. Invalid email address - ${e.address}")
     })

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -14,7 +14,9 @@ package com.flipkart.connekt.commons.iomodels
 
 import javax.mail.internet.InternetAddress
 
+import akka.http.javadsl.model.StatusCodes
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.flipkart.connekt.commons.entities.exception.{ExceptionType, ServiceException}
 import com.flipkart.connekt.commons.factories.{ConnektLogger, LogFile}
 import com.flipkart.connekt.commons.services.ConnektConfig
 import org.apache.commons.validator.routines.EmailValidator
@@ -51,10 +53,14 @@ case class EmailAddress(name: String, address: String) {
   }
 
   def validate(): Unit = {
-    require(EmailValidator.getInstance().isValid(address), s"Bad Request. Invalid email address - $address")
+    if (!EmailValidator.getInstance().isValid(address)) {
+      throw ServiceException(StatusCodes.BAD_REQUEST, ExceptionType.BAD_REQUEST_INVALID_EMAIL, s"Bad Request. Invalid email address - $address")
+    }
     val invalidCharacters = ConnektConfig.getList[String]("email.name.invalid.characters").toSet //fetched by config
     invalidCharacters.foreach(i => {
-      require(!name.contains(i), s"Bad Request. Invalid email name - $name")
+      if (name.contains(i)) {
+        throw ServiceException(StatusCodes.BAD_REQUEST, ExceptionType.BAD_REQUEST_INVALID_NAME, s"Bad Request. Invalid email name - $name")
+      }
     })
   }
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -51,10 +51,10 @@ case class EmailAddress(name: String, address: String) {
   }
 
   def validate(): Unit = {
-    require(!EmailValidator.getInstance().isValid(address), s"Bad Request. Invalid email address - $address")
+    require(EmailValidator.getInstance().isValid(address), s"Bad Request. Invalid email address - $address")
     val invalidCharacters = ConnektConfig.getList[String]("email.name.invalid.characters").toSet //fetched by config
     invalidCharacters.foreach(i => {
-      require(name.contains(i), s"Bad Request. Invalid email name - $name")
+      require(!name.contains(i), s"Bad Request. Invalid email name - $name")
     })
   }
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -15,6 +15,7 @@ package com.flipkart.connekt.commons.iomodels
 import javax.mail.internet.InternetAddress
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.apache.commons.validator.routines.EmailValidator
 
 case class EmailRequestInfo(@JsonProperty(required = false) appName: String,
                             @JsonProperty(required = false) to: Set[EmailAddress] = Set.empty[EmailAddress],
@@ -30,6 +31,11 @@ case class EmailRequestInfo(@JsonProperty(required = false) appName: String,
       cc = Option(cc).map(_.map(_.toStrict)).getOrElse(Set.empty),
       bcc = Option(bcc).map(_.map(_.toStrict)).getOrElse(Set.empty)
     )
+  }
+
+  def validateEmailRequestInfo(emailRequestInfo: EmailRequestInfo): Unit = {
+    val recepients = (emailRequestInfo.to ++ emailRequestInfo.bcc ++ emailRequestInfo.bcc).filter(e => null != e.address && e.address.nonEmpty)
+    recepients.foreach(e => require(!EmailValidator.getInstance().isValid(e.address), s"Bad Request. Invalid email address - $e"))
   }
 }
 

--- a/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
+++ b/commons/src/main/scala/com/flipkart/connekt/commons/iomodels/EmailRequestInfo.scala
@@ -36,12 +36,10 @@ case class EmailRequestInfo(@JsonProperty(required = false) appName: String,
 
   def validate(): Unit = {
     val emailAddresses = (to ++ cc ++ bcc).+(from).+(replyTo).filter(e => null != e.address && e.address.nonEmpty)
-    val invalidCharacters = ConnektConfig.getList[String]("invalid.email.name.characters").toSet
+    val invalidCharacters = ConnektConfig.getList[String]("email.name.invalid.characters").toSet
     emailAddresses.foreach(e => {
       require(!EmailValidator.getInstance().isValid(e.address), s"Bad Request. Invalid email address - ${e.address}")
-    })
-    invalidCharacters.foreach(i => {
-      emailAddresses.foreach(e => {
+      invalidCharacters.foreach(i => {
         require(e.name.contains(i), s"Bad Request. Invalid email name - ${e.name}")
       })
     })

--- a/firefly/src/main/scala/com/flipkart/connekt/firefly/flows/metrics/LatencyMetrics.scala
+++ b/firefly/src/main/scala/com/flipkart/connekt/firefly/flows/metrics/LatencyMetrics.scala
@@ -1,3 +1,15 @@
+/*
+ *         -╥⌐⌐⌐⌐            -⌐⌐⌐⌐-
+ *      ≡╢░░░░⌐\░░░φ     ╓╝░░░░⌐░░░░╪╕
+ *     ╣╬░░`    `░░░╢┘ φ▒╣╬╝╜     ░░╢╣Q
+ *    ║╣╬░⌐        ` ╤▒▒▒Å`        ║╢╬╣
+ *    ╚╣╬░⌐        ╔▒▒▒▒`«╕        ╢╢╣▒
+ *     ╫╬░░╖    .░ ╙╨╨  ╣╣╬░φ    ╓φ░╢╢Å
+ *      ╙╢░░░░⌐"░░░╜     ╙Å░░░░⌐░░░░╝`
+ *        ``˚¬ ⌐              ˚˚⌐´
+ *
+ *      Copyright © 2016 Flipkart.com
+ */
 package com.flipkart.connekt.firefly.flows.metrics
 
 import java.util.concurrent.TimeUnit

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -215,10 +215,7 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
 
                                 val emailRequestInfo = request.channelInfo.asInstanceOf[EmailRequestInfo].toStrict
 
-                                // collect all the to, cc and bcc non empty email addresses
-                                val recipients = (emailRequestInfo.to.map(_.address) ++ emailRequestInfo.cc.map(_.address) ++ emailRequestInfo.bcc.map(_.address)).filter(_.isDefined)
-
-                                recipients.foreach(e => require(!EmailValidator.getInstance().isValid(e), s"Bad Request. Invalid email address - ${e}"))
+                                emailRequestInfo.validateEmailRequestInfo(emailRequestInfo)
 
                                 if (emailRequestInfo.to != null && emailRequestInfo.to.nonEmpty) {
                                   if (isTestRequest) {
@@ -226,6 +223,7 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
                                   } else {
                                     val success = scala.collection.mutable.Map[String, Set[String]]()
                                     val queueName = ServiceFactory.getMessageService(Channel.EMAIL).getRequestBucket(request, user)
+                                    val recipients = (emailRequestInfo.to.map(_.address) ++ emailRequestInfo.cc.map(_.address) ++ emailRequestInfo.bcc.map(_.address)).filter(_.isDefined)
 
                                     //TODO: do an exclusion check
                                     val excludedAddress = recipients.filterNot { address => ExclusionService.lookup(request.channel, appName, address).getOrElse(true) }

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -218,7 +218,7 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
                                 // collect all the to, cc and bcc non empty email addresses
                                 val recipients = (emailRequestInfo.to.map(_.address) ++ emailRequestInfo.cc.map(_.address) ++ emailRequestInfo.bcc.map(_.address)).filter(_.isDefined)
 
-                                recipients.foreach(e => require(!EmailValidator.getInstance().isValid(e), "Bad Request. Invalid email."))
+                                recipients.foreach(e => require(!EmailValidator.getInstance().isValid(e), s"Bad Request. Invalid email address - ${e}"))
 
                                 if (emailRequestInfo.to != null && emailRequestInfo.to.nonEmpty) {
                                   if (isTestRequest) {

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -215,7 +215,7 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
 
                                 val emailRequestInfo = request.channelInfo.asInstanceOf[EmailRequestInfo].toStrict
 
-                                emailRequestInfo.validate
+                                emailRequestInfo.validate()
 
                                 if (emailRequestInfo.to != null && emailRequestInfo.to.nonEmpty) {
                                   if (isTestRequest) {

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -215,7 +215,7 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
 
                                 val emailRequestInfo = request.channelInfo.asInstanceOf[EmailRequestInfo].toStrict
 
-                                emailRequestInfo.validateEmailRequestInfo
+                                emailRequestInfo.validate
 
                                 if (emailRequestInfo.to != null && emailRequestInfo.to.nonEmpty) {
                                   if (isTestRequest) {

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -219,41 +219,35 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
                                     GenericResponse(StatusCodes.BadRequest.intValue, null, SendResponse(s"Request Stencil Validation Failed, for stencilId : ${request.stencilId.get} and ChannelDataMode : ${request.channelDataModel} with ERROR : ${f.getCause}", Map.empty, List.empty)).respond
                                   case Success(_) =>
                                     val emailRequestInfo = request.channelInfo.asInstanceOf[EmailRequestInfo].toStrict
-
                                     emailRequestInfo.validate()
 
-                                    if (emailRequestInfo.to != null && emailRequestInfo.to.nonEmpty) {
-                                      if (isTestRequest) {
-                                        GenericResponse(StatusCodes.Accepted.intValue, null, SendResponse(s"Email Perf Send Request Received. Skipped sending.", Map("fake_message_id" -> r.destinations), List.empty)).respond
-                                      } else {
-                                        val success = scala.collection.mutable.Map[String, Set[String]]()
-                                        val queueName = ServiceFactory.getMessageService(Channel.EMAIL).getRequestBucket(request, user)
-                                        val recipients = (emailRequestInfo.to.map(_.address) ++ emailRequestInfo.cc.map(_.address) ++ emailRequestInfo.bcc.map(_.address)).filter(_.isDefined)
-
-                                        //TODO: do an exclusion check
-                                        val excludedAddress = recipients.filterNot { address => ExclusionService.lookup(request.channel, appName, address).getOrElse(true) }
-                                        val failure = ListBuffer[String](excludedAddress.toSeq: _*)
-                                        val validRecipients = recipients.diff(excludedAddress)
-                                        if (validRecipients.nonEmpty) {
-                                          /* enqueue multiple requests into kafka */
-
-                                          ServiceFactory.getMessageService(Channel.EMAIL).saveRequest(request.copy(channelInfo = emailRequestInfo), queueName) match {
-                                            case Success(id) =>
-                                              success += id -> validRecipients
-                                              ServiceFactory.getReportingService.recordChannelStatsDelta(user.userId, request.contextId, request.stencilId, Channel.EMAIL, appName, InternalStatus.Received, recipients.size)
-                                            case Failure(t) =>
-                                              failure ++= validRecipients
-                                              ServiceFactory.getReportingService.recordChannelStatsDelta(user.userId, request.contextId, request.stencilId, Channel.EMAIL, appName, InternalStatus.Rejected, recipients.size)
-                                          }
-                                          val (responseCode, message) = if (success.nonEmpty) Tuple2(StatusCodes.Accepted, "Email Send Request Received") else Tuple2(StatusCodes.InternalServerError, "Email Send Request Failed")
-                                          GenericResponse(responseCode.intValue, null, SendResponse(message, success.toMap, failure.toList)).respond
-                                        } else {
-                                          GenericResponse(StatusCodes.BadRequest.intValue, null, SendResponse(s"No valid destinations found", success.toMap, failure.toList)).respond
-                                        }
-                                      }
+                                    if (isTestRequest) {
+                                      GenericResponse(StatusCodes.Accepted.intValue, null, SendResponse(s"Email Perf Send Request Received. Skipped sending.", Map("fake_message_id" -> r.destinations), List.empty)).respond
                                     } else {
-                                      ConnektLogger(LogFile.SERVICE).error(s"Request Validation Failed, $request ")
-                                      GenericResponse(StatusCodes.BadRequest.intValue, null, Response("Request Validation Failed, Please ensure mandatory field values.", null)).respond
+                                      val success = scala.collection.mutable.Map[String, Set[String]]()
+                                      val queueName = ServiceFactory.getMessageService(Channel.EMAIL).getRequestBucket(request, user)
+                                      val recipients = (emailRequestInfo.to.map(_.address) ++ emailRequestInfo.cc.map(_.address) ++ emailRequestInfo.bcc.map(_.address)).filter(_.isDefined)
+
+                                      //TODO: do an exclusion check
+                                      val excludedAddress = recipients.filterNot { address => ExclusionService.lookup(request.channel, appName, address).getOrElse(true) }
+                                      val failure = ListBuffer[String](excludedAddress.toSeq: _*)
+                                      val validRecipients = recipients.diff(excludedAddress)
+                                      if (validRecipients.nonEmpty) {
+                                        /* enqueue multiple requests into kafka */
+
+                                        ServiceFactory.getMessageService(Channel.EMAIL).saveRequest(request.copy(channelInfo = emailRequestInfo), queueName) match {
+                                          case Success(id) =>
+                                            success += id -> validRecipients
+                                            ServiceFactory.getReportingService.recordChannelStatsDelta(user.userId, request.contextId, request.stencilId, Channel.EMAIL, appName, InternalStatus.Received, recipients.size)
+                                          case Failure(t) =>
+                                            failure ++= validRecipients
+                                            ServiceFactory.getReportingService.recordChannelStatsDelta(user.userId, request.contextId, request.stencilId, Channel.EMAIL, appName, InternalStatus.Rejected, recipients.size)
+                                        }
+                                        val (responseCode, message) = if (success.nonEmpty) Tuple2(StatusCodes.Accepted, "Email Send Request Received") else Tuple2(StatusCodes.InternalServerError, "Email Send Request Failed")
+                                        GenericResponse(responseCode.intValue, null, SendResponse(message, success.toMap, failure.toList)).respond
+                                      } else {
+                                        GenericResponse(StatusCodes.BadRequest.intValue, null, SendResponse(s"No valid destinations found", success.toMap, failure.toList)).respond
+                                      }
                                     }
                                 }
                               }

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -215,7 +215,7 @@ class SendRoute(implicit am: ActorMaterializer) extends BaseJsonHandler {
 
                                 val emailRequestInfo = request.channelInfo.asInstanceOf[EmailRequestInfo].toStrict
 
-                                emailRequestInfo.validateEmailRequestInfo(emailRequestInfo)
+                                emailRequestInfo.validateEmailRequestInfo
 
                                 if (emailRequestInfo.to != null && emailRequestInfo.to.nonEmpty) {
                                   if (isTestRequest) {

--- a/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
+++ b/receptors/src/main/scala/com/flipkart/connekt/receptors/routes/master/SendRoute.scala
@@ -30,8 +30,6 @@ import com.flipkart.connekt.receptors.routes.helper.{PhoneNumberHelper, WAContac
 import com.flipkart.connekt.receptors.wire.ResponseUtils._
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat
-import org.apache.commons.validator.routines.EmailValidator
-
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/com/flipkart/connekt/boot/Boot.scala
+++ b/src/main/scala/com/flipkart/connekt/boot/Boot.scala
@@ -52,7 +52,7 @@ object Boot extends App {
 
       case "barklice" =>
         sys.addShutdownHook(BarkLiceBoot.terminate())
-        BarkLiceBoot.start
+        BarkLiceBoot.start()
 
       case _ =>
         println(usage)


### PR DESCRIPTION
 - Email validations put to make sure if any of the addresses are incorrect, the API would respond with a 400 (BadRequest).
 - Using existing apache library for [`isValid`](https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/EmailValidator.html#isValid(java.lang.String)) check over email address.
 - Stencil validation over the send/email request
 - Minor import and formatting fixes